### PR TITLE
linking urls

### DIFF
--- a/components/navbar/index.tsx
+++ b/components/navbar/index.tsx
@@ -7,18 +7,19 @@ interface NavbarProps {
     domain: string;
 }
 
-const loggedIn = false; //TODO: replace once we connect with backend
+const loggedIn = true; //TODO: replace once we connect with backend
 
+//TODO: set all the proper links
 const loggedInComicsSettings = [
     { display: "Start New Comic", url: "/" },
-    { display: "My Comics", url: "/" },
+    { display: "My Comics", url: "/comic/my" },
     { display: "My Profile", url: "/" },
     { display: "Account Settings", url: "/" },
     { display: "Log Out", url: "/" },
 ];
 const loggedInStoriesSettings = [
     { display: "Start New Story", url: "/" },
-    { display: "My Stories", url: "/" },
+    { display: "My Stories", url: "/story/my" },
     { display: "My Profile", url: "/" },
     { display: "Account Settings", url: "/" },
     { display: "Log Out", url: "/" },

--- a/components/postlogin/index.tsx
+++ b/components/postlogin/index.tsx
@@ -28,7 +28,7 @@ const PostLoginPage: React.FC = () => {
                 <Box>
                     <Button
                         component="a"
-                        href="/"
+                        href="/comic/hub"
                         variant="outlined"
                         sx={{
                             marginRight: "75px",
@@ -45,7 +45,7 @@ const PostLoginPage: React.FC = () => {
                 <Box>
                     <Button
                         component="a"
-                        href="/"
+                        href="/story/hub"
                         variant="outlined"
                         sx={{
                             marginRight: "75px",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,7 +4,7 @@ import PostLoginPage from "../components/postlogin";
 import LandingPage from "../components/landing";
 import Navbar from "../components/navbar";
 
-const loggedIn = false; //TODO: replace once we connect with backend
+const loggedIn = true; //TODO: replace once we connect with backend
 
 const Home: NextPage = () => {
     return (
@@ -12,8 +12,7 @@ const Home: NextPage = () => {
             <Head>
                 <title>Zomp</title>
             </Head>
-            {/* TODO: dynamically set navbar */}
-            <Navbar domain="comics" />
+            <Navbar domain="" />
             {loggedIn ? <PostLoginPage /> : <LandingPage />}
         </div>
     );


### PR DESCRIPTION
_UPDATED_
linked postlogin page to the community hub of the corresponding page
linked some of the options in the menu to their corresponding URLs
set default state for zomp.works to the postlogin screen to show connection to the community hub

No UI change, so no screenshots