### PR TITLE
added basic context setup

### DIFF
--- a/components/postlogin/index.tsx
+++ b/components/postlogin/index.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 import { Box, Button, Typography } from "@mui/material";
-
-//TODO: replace once we connect to backend
-const user = "Mason";
+import { useAuthContext } from "../../context/authcontext";
 
 const PostLoginPage: React.FC = () => {
+    const { user } = useAuthContext();
+
     return (
         <>
             <Typography
@@ -16,7 +16,7 @@ const PostLoginPage: React.FC = () => {
                     fontWeight: "bolder",
                 }}
             >
-                Hi {user}! What do you want to do today?
+                Hi {user ? user.username : "uh oh"}! What do you want to do today?
             </Typography>
 
             <Box

--- a/context/authcontext/index.tsx
+++ b/context/authcontext/index.tsx
@@ -1,0 +1,35 @@
+import React, { createContext, useContext } from "react";
+
+interface IUser {
+    email: string;
+    username: string;
+    password: string;
+    verified: boolean;
+    comics: string[];
+    stories: string[];
+    subscriptions: string[];
+    subscriberCount: number;
+    profilePicture?: string;
+    comicRatings: {
+        id: string;
+        rating: number;
+    }[];
+    storyRatings: {
+        id: string;
+        rating: number;
+    }[];
+    createdAt: Date;
+    updatedAt: Date;
+}
+
+interface IAuthContext {
+    user: IUser | undefined;
+}
+
+const AuthContext = createContext<IAuthContext>({ user: undefined });
+
+export const AuthProvider: React.FC<{ user?: IUser }> = ({ children, user }) => {
+    return <AuthContext.Provider value={{ user }}>{children}</AuthContext.Provider>;
+};
+
+export const useAuthContext = () => useContext(AuthContext);

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,14 +1,13 @@
 import type { NextPage, GetServerSideProps } from "next";
 import Head from "next/head";
+import { AuthProvider } from "../context/authcontext";
 import PostLoginPage from "../components/postlogin";
 import LandingPage from "../components/landing";
 import Navbar from "../components/navbar";
 import { getUserFromSession } from "../util/zilean";
 
-// TEMP prop interface to simply indicate log in status,
-// We want to eventually pass the user instead (if there is one)
 interface Props {
-    loggedIn: boolean;
+    user: any;
 }
 
 const Home: NextPage<Props> = props => {
@@ -17,8 +16,10 @@ const Home: NextPage<Props> = props => {
             <Head>
                 <title>Zomp</title>
             </Head>
-            <Navbar domain="" />
-            {props.loggedIn ? <PostLoginPage /> : <LandingPage />}
+            <AuthProvider user={props.user}>
+                <Navbar domain="" />
+                {props.user ? <PostLoginPage /> : <LandingPage />}
+            </AuthProvider>
         </div>
     );
 };
@@ -26,19 +27,9 @@ const Home: NextPage<Props> = props => {
 export const getServerSideProps: GetServerSideProps<Props> = async context => {
     const result = await getUserFromSession(context.req.headers.cookie || "");
 
-    // If there is an error, the user it not logged in
-    if (result.error) {
-        return {
-            props: {
-                loggedIn: false,
-            },
-        };
-    }
-
-    // No error means that the backend was able to retrieve the user from the session cookie.
     return {
         props: {
-            loggedIn: true,
+            user: result.data || null,
         },
     };
 };


### PR DESCRIPTION
Added context for the logged in user, and code to show how it works in post-login. Essentially:

1. `import { AuthProvider }` and then wrap everything in `<AuthProvider user={...} />` for everything inside `pages/`.
2. `import { useAuthContext }` and then `const { user } = useAuthContext()` in any components where you need to access the current user.

<img width="590" alt="image" src="https://user-images.githubusercontent.com/35638530/162828798-094bc39c-00c0-45d1-88f1-19a8ccf75c0a.png">

A few questions:
- where should context definitions go? Right now I have it in `context/authcontext` (note that we eventually need contexts for individual comic and story as well) 
- should it be called `authContext` or `userContext`
- do we need a folder for declaring types/interfaces? (e.g. `IUser`)