### PR TITLE
Overhauled Edit Story Page

### DIFF
--- a/components/profile/results/index.tsx
+++ b/components/profile/results/index.tsx
@@ -22,10 +22,11 @@ const ResultCard: React.FC<{ comic?: any; user?: any }> = ({ comic, user }) => {
     const [comicImage, setComicImage] = useState<string>("");
     useEffect(() => {
         async function getComicImage() {
-            console.log(comic.renderedImage);
             if (comic.renderedImage !== undefined) {
                 const { data } = await getImage(comic.renderedImage.toString());
-                setComicImage("https://zomp-media.s3.us-east-1.amazonaws.com/" + data.imageURL);
+                if (data.error) alert(data.error);
+                else
+                    setComicImage("https://zomp-media.s3.us-east-1.amazonaws.com/" + data.imageURL);
             }
         }
         getComicImage();

--- a/components/story/edit/editor/index.tsx
+++ b/components/story/edit/editor/index.tsx
@@ -1,0 +1,66 @@
+import React, { useState } from "react";
+import { Button, Typography, IconButton } from "@mui/material";
+import UndoIcon from "@mui/icons-material/Undo";
+import RedoIcon from "@mui/icons-material/Redo";
+import EditIcon from "@mui/icons-material/Edit";
+import SaveIcon from "@mui/icons-material/Save";
+import * as Styled from "./styles";
+import "react-quill/dist/quill.snow.css";
+import dynamic from "next/dynamic";
+import { useStoryContext } from "../../../../context/storycontext";
+
+const ReactQuill = dynamic(import("react-quill"), {
+    ssr: false,
+    loading: () => <div>Loading Text Editor...</div>,
+});
+
+const Editor: React.FC = () => {
+    const [changed, setChanged] = useState<boolean>(false);
+    const { story } = useStoryContext();
+    return (
+        <>
+            <Styled.Story>
+                <Styled.TitleContainer>
+                    <Styled.ButtonContainer>
+                        <Button
+                            variant="contained"
+                            color="primary"
+                            startIcon={<SaveIcon />}
+                            onClick={() => {
+                                setChanged(false);
+                            }}
+                        >
+                            Save {changed && "*"}
+                        </Button>
+                        <IconButton>
+                            <UndoIcon color="primary" />
+                        </IconButton>
+                        <IconButton>
+                            <RedoIcon color="primary" />
+                        </IconButton>
+                    </Styled.ButtonContainer>
+                    <Styled.ChapterContainer>
+                        <Typography variant="h4" sx={{ fontWeight: "bold" }}>
+                            Chapter 1
+                            <IconButton>
+                                <EditIcon color="primary" />
+                            </IconButton>
+                        </Typography>
+                    </Styled.ChapterContainer>
+                </Styled.TitleContainer>
+                <ReactQuill
+                    defaultValue={story!.story}
+                    placeholder="Start Typing..."
+                    style={{ marginLeft: "10px", width: "98%" }}
+                    onChange={(_, __, source) => {
+                        if (!changed && source === "user") {
+                            setChanged(true);
+                        }
+                    }}
+                />
+            </Styled.Story>
+        </>
+    );
+};
+
+export default Editor;

--- a/components/story/edit/editor/styles.ts
+++ b/components/story/edit/editor/styles.ts
@@ -1,0 +1,30 @@
+import styled from "@emotion/styled";
+
+export const TitleContainer = styled.div`
+    display: flex;
+    flex-direction: row;
+    width: 100%;
+    justify-content: flex-start;
+    margin-bottom: 25px;
+`;
+
+export const ButtonContainer = styled.div`
+    display: flex;
+    flex-direction: row;
+    width: 16%;
+    margin-left: 10px;
+    margin-right: 330px;
+`;
+
+export const ChapterContainer = styled.div`
+    display: flex;
+    flex-direction: row;
+    width: 17%;
+`;
+
+export const Story = styled.div`
+    display: flex;
+    flex-direction: column;
+    margin-top: 20px;
+    width: 100%;
+`;

--- a/components/story/edit/index.tsx
+++ b/components/story/edit/index.tsx
@@ -1,191 +1,38 @@
-import React, { useState } from "react";
-import {
-    Box,
-    Button,
-    Typography,
-    IconButton,
-    List,
-    ListItem,
-    ListItemAvatar,
-    ListItemText,
-    Dialog,
-    DialogTitle,
-    TextField,
-} from "@mui/material";
-import ChevronRightIcon from "@mui/icons-material/ChevronRight";
-import EditIcon from "@mui/icons-material/Edit";
-import SaveIcon from "@mui/icons-material/Save";
-import DeleteIcon from "@mui/icons-material/Delete";
-import AddIcon from "@mui/icons-material/Add";
+import React, { createContext, useState, useContext } from "react";
 import * as Styled from "./styles";
 import "react-quill/dist/quill.snow.css";
-import dynamic from "next/dynamic";
+import Editor from "./editor";
+import Toolbar from "./toolbar";
+import Widebar from "./widebar";
 
-const ReactQuill = dynamic(import("react-quill"), {
-    ssr: false,
-    loading: () => <div>Loading Text Editor...</div>,
-});
+interface IEditContext {
+    tool: string;
+    setTool?: React.Dispatch<React.SetStateAction<string>>;
+    saveStory?: () => Promise<void>;
+    publishStory?: (file: File) => Promise<void>;
+}
 
-//TODO remove
-const story = {
-    _id: "a2",
-    title: "Crewmate",
-    author: "amogus",
-    description:
-        "Among Us is a 2018 online multiplayer social deduction game developed and published by \
-        American game studio Innersloth. The game was inspired by the party game Mafia and the science \
-        fiction horror film The Thing. The game allows for cross-platform play, first being released on \
-        iOS and Android devices in June 2018 and on Windows later that year in November.",
-    splashURL:
-        "https://images.fineartamerica.com/images/artworkimages/mediumlarge/3/crewmate-indra-tirto.jpg",
-    published: false,
-    rating: 4.3,
-    views: 210,
-};
+const EditContext = createContext<IEditContext>({ tool: "" });
 
-//TODO add ui to view all chapters and make edit chapter name work(?) and edit title work
-const ViewStory: React.FC = () => {
-    const [modalOpen, setModalOpen] = useState<boolean>(false);
-    const [changed, setChanged] = useState<boolean>(false);
-    const [tags, setTags] = useState<string[]>(["Comedy", "College"]);
-    const [addTag, setAddTag] = useState<string>("");
+const EditStory: React.FC = () => {
+    const [tool, setTool] = useState("");
+    const saveStory = async () => {};
+    const publishStory = async () => {};
 
     return (
         <>
-            <Dialog
-                open={modalOpen}
-                onClose={() => {
-                    setModalOpen(false);
-                }}
-                fullWidth
-                PaperProps={{
-                    style: {
-                        backgroundColor: "#E6F4F1",
-                    },
-                }}
-            >
-                <DialogTitle sx={{ padding: "16px 16px" }}>Manage Tags</DialogTitle>
-                <List>
-                    {tags.map((val, index) => (
-                        <ListItem key={`${index}-modal-tag`}>
-                            <ListItemText primary={val} />
-                            <ListItemAvatar>
-                                <IconButton
-                                    onClick={() => {
-                                        setTags(tags.filter(tag => tag !== val));
-                                    }}
-                                >
-                                    <DeleteIcon />
-                                </IconButton>
-                            </ListItemAvatar>
-                        </ListItem>
-                    ))}
-                    <ListItem>
-                        <ListItemText
-                            primary={
-                                <TextField
-                                    margin="dense"
-                                    id="addTag"
-                                    label="Add Tag"
-                                    type="text"
-                                    fullWidth
-                                    variant="standard"
-                                    value={addTag}
-                                    onChange={e => {
-                                        setAddTag(e.target.value);
-                                    }}
-                                />
-                            }
-                        />
-                        <ListItemAvatar>
-                            <IconButton
-                                disabled={!addTag}
-                                onClick={() => {
-                                    setTags([...tags, addTag]);
-                                    setAddTag("");
-                                }}
-                            >
-                                <AddIcon />
-                            </IconButton>
-                        </ListItemAvatar>
-                    </ListItem>
-                </List>
-            </Dialog>
-            <Styled.ViewStoryContainer>
-                <Styled.RowContainer>
-                    <Box
-                        component="img"
-                        sx={{
-                            height: 100,
-                            width: 70,
-                            paddingRight: "10px",
-                        }}
-                        alt={story.title}
-                        src={story.splashURL}
-                    />
-                    <Styled.ColumnContainer>
-                        <Typography
-                            variant="h4"
-                            width={"100%"}
-                            sx={{ paddingTop: "10px", marginBottom: "5px" }}
-                        >
-                            Story Title
-                            <IconButton>
-                                <EditIcon color="primary" />
-                            </IconButton>
-                        </Typography>
-                        <Styled.TVContainer>
-                            <Styled.TagsContainer>
-                                {tags.map((val, index) => (
-                                    <Styled.Tag key={`${index}-tag`}>{val}</Styled.Tag>
-                                ))}
-                                <Styled.ManageTag
-                                    onClick={() => {
-                                        setModalOpen(true);
-                                    }}
-                                >
-                                    Manage Tags
-                                </Styled.ManageTag>
-                            </Styled.TagsContainer>
-                        </Styled.TVContainer>
-                    </Styled.ColumnContainer>
-                </Styled.RowContainer>
-                <Styled.Story>
-                    <Styled.ButtonsContainer>
-                        <Button
-                            variant="contained"
-                            color="primary"
-                            startIcon={<SaveIcon />}
-                            onClick={() => {
-                                setChanged(false);
-                            }}
-                        >
-                            Save {changed && "*"}
-                        </Button>
-                        <Typography variant="h4" sx={{ fontWeight: "bold" }}>
-                            Chapter 1
-                            <IconButton>
-                                <EditIcon color="primary" />
-                            </IconButton>
-                        </Typography>
-                        <Button variant="contained" color="primary" endIcon={<ChevronRightIcon />}>
-                            Chapter 2
-                        </Button>
-                    </Styled.ButtonsContainer>
-                    <ReactQuill
-                        defaultValue={story.description}
-                        placeholder="Start Typing..."
-                        style={{ flex: 1 }}
-                        onChange={(_, __, source) => {
-                            if (!changed && source === "user") {
-                                setChanged(true);
-                            }
-                        }}
-                    />
-                </Styled.Story>
-            </Styled.ViewStoryContainer>
+            <EditContext.Provider value={{ tool, setTool, saveStory, publishStory }}>
+                <Styled.EditorOuter>
+                    <Styled.EditorInner>
+                        <Toolbar />
+                        <Widebar />
+                        <Editor />
+                    </Styled.EditorInner>
+                </Styled.EditorOuter>
+            </EditContext.Provider>
         </>
     );
 };
+export const useEditContext = () => useContext(EditContext);
 
-export default ViewStory;
+export default EditStory;

--- a/components/story/edit/styles.ts
+++ b/components/story/edit/styles.ts
@@ -1,135 +1,15 @@
 import styled from "@emotion/styled";
-import { Avatar as MUI_Avatar, Button as MUI_Button } from "@mui/material";
 
-export const ViewStoryContainer = styled.div`
+export const EditorOuter = styled.div`
     width: 100%;
-    padding: 30px 25%;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    text-align: left;
-    margin-top: 50px;
+    height: 100%;
+    position: fixed;
+    padding-top: 50px;
 `;
-
-export const ButtonsContainer = styled.div`
-    display: flex;
-    flex-direction: row;
+export const EditorInner = styled.div`
     width: 100%;
-    justify-content: space-between;
-    margin-top: 25px;
-    margin-bottom: 25px;
-`;
-
-export const RowContainer = styled.div`
-    width: 100%;
+    height: 100%;
     display: flex;
     flex-direction: row;
-`;
-
-export const ColumnContainer = styled.div`
-    width: 100%;
-    display: flex;
-    flex-direction: column;
-`;
-
-export const TVContainer = styled.div`
-    display: flex;
-    flex-direction: row;
-    width: 100%;
-    justify-content: space-between;
-`;
-
-export const TagsContainer = styled.div`
-    display: flex;
-    flex-direction: row;
-    min-width: 50%;
-    justify-content: left;
-    margin-bottom: 5px;
-`;
-
-export const ViewContainer = styled.div`
-    display: flex;
-    flex-direction: row;
-    min-width: 50%;
-    justify-content: right;
-`;
-
-export const Tag = styled(MUI_Button)`
-    background-color: white;
-    border: 2px solid #39a78e;
-    border-radius: 15px;
-    height: 30px;
-    padding: 3px 10px;
-    margin-right: 10px;
-`;
-
-export const ManageTag = styled(Tag)`
-    color: black;
-    background-color: #39a78e;
-    border: 2px dashed black;
-    font-weight: bold;
-
-    :hover {
-        background-color: #2e8c76;
-        border: 2px dashed black;
-        cursor: pointer;
-    }
-`;
-
-export const Story = styled.div`
-    display: flex;
-    flex-direction: column;
-    width: 100%;
-    margin: 25px;
-`;
-
-// Author + Share and Subscribe lol
-export const ASSContainer = styled.div`
-    margin-top: 20px;
-    margin-bottom: 20px;
-    width: 90%;
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-`;
-
-export const AuthorContainer = styled.div`
-    display: flex;
-    flex-direction: row;
-`;
-
-export const Avatar = styled(MUI_Avatar)`
-    width: 60px;
-    height: 60px;
-    margin-right: 5px;
-`;
-
-export const SSButton = styled(MUI_Button)`
-    padding: 2px 10px;
-    margin-left: 5px;
-    text-align: center;
-    height: 40px;
-    line-height: 40px;
-`;
-
-export const SSContainer = styled.div`
-    display: flex;
-    flex-direction: row;
-    min-width: 50%;
-    justify-content: right;
-`;
-
-export const RatingsContainer = styled.div`
-    width: 45%;
-    display: flex;
-    flex-direction: column;
-    align-items: right;
-`;
-
-export const Rating = styled.div`
-    width: 100%;
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    align-items: center;
+    align-items: top;
 `;

--- a/components/story/edit/toolbar/index.tsx
+++ b/components/story/edit/toolbar/index.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { Divider } from "@mui/material";
+import TitleIcon from "@mui/icons-material/Title";
+import TagIcon from "@mui/icons-material/Tag";
+import ImageIcon from "@mui/icons-material/Image";
+import * as Styled from "./styles";
+import ToolTab from "./tooltab";
+
+const Actions: React.FC = () => {
+    return (
+        <Styled.Toolbar>
+            <Divider sx={{ margin: "5px", visibility: "hidden" }} />
+            <ToolTab icon={<TitleIcon />} text="EDIT TITLE/DESCRIPTION" name={"title"} />
+            <ToolTab icon={<ImageIcon />} text="CHANGE COVER ART" name={"coverart"} />
+            <ToolTab icon={<TagIcon />} text="MANAGE TAGS" name={"tags"} />
+            <Divider sx={{ margin: "2px", visibility: "hidden" }} />
+        </Styled.Toolbar>
+    );
+};
+
+export default Actions;

--- a/components/story/edit/toolbar/styles.ts
+++ b/components/story/edit/toolbar/styles.ts
@@ -1,0 +1,12 @@
+import styled from "@emotion/styled";
+
+export const Toolbar = styled.div`
+    height: 100%;
+    width: 40px;
+    display: flex;
+    flex-direction: column;
+    background-color: "#E6F4F1";
+    box-sizing: content-box;
+    border-right: 1px solid #39a78d;
+    row-gap: 6px;
+`;

--- a/components/story/edit/toolbar/tooltab/index.tsx
+++ b/components/story/edit/toolbar/tooltab/index.tsx
@@ -1,0 +1,33 @@
+import React, { useState } from "react";
+import { Typography } from "@mui/material";
+import * as Styled from "./styles";
+import { useEditContext } from "../..";
+
+const ToolItem: React.FC<{ icon: React.ReactNode; text: string; name: string }> = props => {
+    const [hovered, setHovered] = useState(false);
+    const { tool, setTool } = useEditContext();
+
+    const toggleTool = () => {
+        setTool!(props.name === tool ? "" : props.name);
+    };
+
+    return (
+        <Styled.Item
+            onMouseOver={() => setHovered(true)}
+            onMouseOut={() => setHovered(false)}
+            onClick={toggleTool}
+        >
+            {tool === props.name ? <Styled.Highlight /> : <></>}
+            <Styled.ToolIcon>{props.icon}</Styled.ToolIcon>
+            {hovered && tool !== props.name ? (
+                <Styled.Tooltip>
+                    <Typography variant="subtitle1">{props.text}</Typography>
+                </Styled.Tooltip>
+            ) : (
+                <></>
+            )}
+        </Styled.Item>
+    );
+};
+
+export default ToolItem;

--- a/components/story/edit/toolbar/tooltab/styles.ts
+++ b/components/story/edit/toolbar/tooltab/styles.ts
@@ -1,0 +1,39 @@
+import styled from "@emotion/styled";
+
+export const Item = styled.div`
+    height: 40px;
+    width: 40px;
+`;
+
+export const Highlight = styled.div`
+    position: absolute;
+    width: 40px;
+    height: 40px;
+    box-sizing: border-box;
+    border-left: 5px solid #39a78d;
+    background-color: #ccc;
+    z-index: 20;
+`;
+
+export const ToolIcon = styled.div`
+    position: absolute;
+    width: 40px;
+    height: 40px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    cursor: pointer;
+    z-index: 30;
+`;
+
+export const Tooltip = styled.div`
+    position: absolute;
+    height: 40px;
+    padding-left: 45px;
+    padding-right: 7px;
+    background-color: #39a78d;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 10;
+`;

--- a/components/story/edit/widebar/index.tsx
+++ b/components/story/edit/widebar/index.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import * as Styled from "./styles";
+import Title from "./title";
+import TitleProperties from "./properties/title";
+import TagProperties from "./properties/tags";
+import CoverArtProperties from "./properties/coverart";
+
+import { useEditContext } from "..";
+
+const Actions: React.FC = () => {
+    const { tool } = useEditContext();
+
+    return (
+        <Styled.Widebar>
+            <Title />
+            {tool === "title" && <TitleProperties />}
+            {tool === "tags" && <TagProperties />}
+            {tool === "coverart" && <CoverArtProperties />}
+        </Styled.Widebar>
+    );
+};
+
+export default Actions;

--- a/components/story/edit/widebar/properties/coverart.tsx
+++ b/components/story/edit/widebar/properties/coverart.tsx
@@ -1,0 +1,85 @@
+import { List, ListItem, Input, Button } from "@mui/material";
+import React, { useState, useEffect } from "react";
+import { useStoryContext } from "../../../../../context/storycontext";
+import { createImage, getImage } from "../../../../../util/zilean";
+
+const CoverArtProperties: React.FC = () => {
+    const [upload, setUpload] = useState<File>();
+    const [uploadDims, setUploadDims] = useState({ width: 100, height: 100 });
+    const [imagePreview, setImagePreview] = useState("");
+    const [finalImage, setFinalImage] = useState<File>();
+    const { story } = useStoryContext();
+    const [coverArt, setCoverArt] = useState<string>("");
+    useEffect(() => {
+        async function getCoverArt() {
+            if (story!.coverart !== undefined) {
+                const { data } = await getImage(story!.coverart.toString());
+                setCoverArt("https://zomp-media.s3.us-east-1.amazonaws.com/" + data.imageURL);
+            }
+        }
+        getCoverArt();
+    });
+
+    const doUpload = async () => {
+        let form = new FormData();
+        form.append("image", upload!);
+        form.append("directory", "thumbnails");
+        form.append("name", upload!.name.split(".")[0]);
+        const { data, error } = await createImage(form);
+        if (error) alert(error);
+    };
+
+    const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        const { name, value } = event.target;
+        setImagePreview(URL.createObjectURL(event.target.files![0]));
+        setFinalImage(event.target.files![0]);
+    };
+    console.log(finalImage);
+
+    return (
+        <List>
+            <ListItem>
+                {coverArt === undefined ? (
+                    <div></div>
+                ) : finalImage === undefined ? (
+                    <img
+                        src={coverArt}
+                        style={{
+                            width: "230px",
+                            height: "400px",
+                            marginLeft: "10px",
+                            objectFit: "cover",
+                        }}
+                    ></img>
+                ) : (
+                    <img
+                        src={imagePreview}
+                        style={{
+                            width: "230px",
+                            height: "400px",
+                            marginLeft: "10px",
+                            objectFit: "cover",
+                        }}
+                    ></img>
+                )}
+            </ListItem>
+            <ListItem>
+                <label htmlFor="contained-button-file">
+                    <Input
+                        inputProps={{ accept: "image/*" }}
+                        name="profilePicture"
+                        type="file"
+                        id="contained-button-file"
+                        style={{ display: "none" }}
+                        onChange={handleInputChange}
+                    />
+                    <Button variant="contained" component="span" style={{ marginLeft: "40px" }}>
+                        Change Cover Art
+                    </Button>
+                </label>
+            </ListItem>
+        </List>
+    );
+};
+
+export default CoverArtProperties;

--- a/components/story/edit/widebar/properties/tags.tsx
+++ b/components/story/edit/widebar/properties/tags.tsx
@@ -1,0 +1,78 @@
+import React, { useState } from "react";
+import {
+    TextField,
+    Typography,
+    List,
+    ListItem,
+    ListItemText,
+    ListItemAvatar,
+    IconButton,
+} from "@mui/material";
+import AddIcon from "@mui/icons-material/Add";
+import DeleteIcon from "@mui/icons-material/Delete";
+import { useStoryContext } from "../../../../../context/storycontext";
+
+const TagProperties: React.FC = () => {
+    const [addTag, setAddTag] = useState<string>("");
+    const { story } = useStoryContext();
+
+    if (!story) {
+        return <div></div>;
+    }
+
+    return (
+        <div>
+            <List>
+                {story.tags.map((val, index) => (
+                    <ListItem key={`${index}-modal-tag`}>
+                        <ListItemText primary={val} />
+                        <ListItemAvatar>
+                            <IconButton
+                            // onClick={() => {
+                            //     newdo("editComic", {
+                            //         tags: comic.tags.filter(tag => tag !== val),
+                            //     });
+                            // }}
+                            >
+                                <DeleteIcon />
+                            </IconButton>
+                        </ListItemAvatar>
+                    </ListItem>
+                ))}
+                <ListItem>
+                    <ListItemText
+                        primary={
+                            <TextField
+                                margin="dense"
+                                id="addTag"
+                                label="Add Tag"
+                                type="text"
+                                fullWidth
+                                variant="standard"
+                                value={addTag}
+                                onChange={e => {
+                                    setAddTag(e.target.value);
+                                }}
+                            />
+                        }
+                    />
+                    <ListItemAvatar>
+                        <IconButton
+                            disabled={!addTag}
+                            // onClick={() => {
+                            //     newdo("editComic", {
+                            //         tags: [...comic.tags, addTag],
+                            //     });
+                            //     setAddTag("");
+                            // }}
+                        >
+                            <AddIcon />
+                        </IconButton>
+                    </ListItemAvatar>
+                </ListItem>
+            </List>
+        </div>
+    );
+};
+
+export default TagProperties;

--- a/components/story/edit/widebar/properties/title.tsx
+++ b/components/story/edit/widebar/properties/title.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { TextField, List, ListItem } from "@mui/material";
+import { useStoryContext } from "../../../../../context/storycontext";
+
+const TitleProperties: React.FC = () => {
+    const { story } = useStoryContext();
+
+    return (
+        <List>
+            <ListItem>
+                <TextField
+                    name="title"
+                    label="Title"
+                    type="text"
+                    variant="outlined"
+                    fullWidth
+                    value={story ? story.title : "Unnamed Comic"}
+                    // onChange={e => {
+                    //     newdo("editComic", {
+                    //         squish: "title",
+                    //         title: e.target.value,
+                    //     });
+                    // }}
+                />
+            </ListItem>
+            <ListItem>
+                <TextField
+                    name="description"
+                    label="Description"
+                    type="text"
+                    variant="outlined"
+                    fullWidth
+                    multiline
+                    rows={10}
+                    maxRows={10}
+                    value={story ? story.description : ""}
+                    // onChange={e => {
+                    //     newdo("editComic", {
+                    //         squish: "description",
+                    //         description: e.target.value,
+                    //     });
+                    // }}
+                />
+            </ListItem>
+        </List>
+    );
+};
+
+export default TitleProperties;

--- a/components/story/edit/widebar/styles.ts
+++ b/components/story/edit/widebar/styles.ts
@@ -1,0 +1,17 @@
+import styled from "@emotion/styled";
+
+export const Widebar = styled.div`
+    height: 100%;
+    width: 360px;
+    background-color: white;
+    box-sizing: content-box;
+    padding: 10px;
+    overflow: scroll;
+    border-right: 1px solid #39a78d;
+    * {
+        -ms-overflow-style: none;
+    }
+    ::-webkit-scrollbar {
+        display: none;
+    }
+`;

--- a/components/story/edit/widebar/title.tsx
+++ b/components/story/edit/widebar/title.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { Typography } from "@mui/material";
+import { useEditContext } from "..";
+
+const title = (tool: string) => {
+    switch (tool) {
+        case "title":
+            return "Edit Title/Description";
+        case "tags":
+            return "Manage Tags";
+        case "coverart":
+            return "Change Cover Art";
+        default:
+            return "";
+    }
+};
+
+const Title: React.FC = () => {
+    const { tool } = useEditContext();
+
+    return (
+        <div style={{ width: "100%", textAlign: "center", padding: "10px" }}>
+            <Typography variant="h6" fontWeight="bold">
+                {title(tool)}
+            </Typography>
+        </div>
+    );
+};
+
+export default Title;

--- a/context/storycontext/index.tsx
+++ b/context/storycontext/index.tsx
@@ -1,0 +1,15 @@
+import React, { createContext, useContext, useEffect, useState } from "react";
+
+import { IStory } from "./model";
+
+interface IStoryContext {
+    story: IStory | undefined;
+}
+
+const StoryContext = createContext<IStoryContext>({ story: undefined });
+
+export const StoryProvider: React.FC<{ story?: IStory }> = ({ children, story }) => {
+    return <StoryContext.Provider value={{ story }}>{children}</StoryContext.Provider>;
+};
+
+export const useStoryContext = () => useContext(StoryContext);

--- a/context/storycontext/ops.ts
+++ b/context/storycontext/ops.ts
@@ -1,0 +1,6 @@
+// import { ILayer, IComic } from "./model";
+
+export interface Op {
+    redo: () => void;
+    undo: () => void;
+}

--- a/pages/story/edit/[id].tsx
+++ b/pages/story/edit/[id].tsx
@@ -3,10 +3,13 @@ import Head from "next/head";
 import EditStory from "../../../components/story/edit";
 import Navbar from "../../../components/navbar";
 import { AuthProvider } from "../../../context/authcontext";
-import { getUserFromSession } from "../../../util/zilean";
+import { StoryProvider } from "../../../context/storycontext";
+import { IStory } from "../../../context/storycontext/model";
+import { getUserFromSession, getStory } from "../../../util/zilean";
 
 interface Props {
     user: any;
+    story: IStory;
 }
 
 const LoginPage: NextPage<Props> = props => {
@@ -16,8 +19,10 @@ const LoginPage: NextPage<Props> = props => {
                 <title>Story Title</title>
             </Head>
             <AuthProvider user={props.user}>
-                <Navbar domain="stories" />
-                <EditStory />
+                <StoryProvider story={props.story}>
+                    <Navbar domain="stories" />
+                    <EditStory />
+                </StoryProvider>
             </AuthProvider>
         </>
     );
@@ -43,11 +48,13 @@ export const getServerSideProps: GetServerSideProps = async context => {
     };
 
     const result = await getUserFromSession(context.req.headers.cookie || "");
+    const storyRes = await getStory(context.params?.id as string);
+
     //TODO confirm proper author
     //TODO should be story
     return {
         props: {
-            comic: testComic,
+            story: storyRes.data,
             user: result.data || null,
         },
     };


### PR DESCRIPTION
<img width="1512" alt="Screen Shot 2022-04-25 at 10 16 18 PM" src="https://user-images.githubusercontent.com/70971809/165206334-8ca21ead-dacc-4b3d-bca7-e9770a9becce.png">

-Overhauled Edit Story Page to match Edit Comic Page's styling
-Added a toolbar for editing title, description, tags, cover art
-Hopefully adding/editing/viewing chapters can be done in the toolbar 

No Functionality done yet but just wanted to merge this to avoid conflicts. 
