### PR TITLE
Matt

### DIFF
--- a/components/comic/edit/widebar/properties/text.tsx
+++ b/components/comic/edit/widebar/properties/text.tsx
@@ -37,7 +37,6 @@ const TextProperties: React.FC = () => {
 
     const onSetFontSize = (e: any) => {
         let size = parseInt(e.target.value);
-        console.log(e.target.value);
         if (isNaN(size)) size = 0;
         if (size > 1000) size = 999;
         setFontSize(size);


### PR DESCRIPTION
![Screen Shot 2022-05-04 at 3 43 17 PM](https://user-images.githubusercontent.com/70971809/166813938-63c1066e-2c2d-4174-af75-b9421c32c607.png)

Removed the lower bound for text size because it was causing digits to be appended and not replaced.
Ex: 16 is the default but when you backspace it turns into 10 and you can't edit the 0. 